### PR TITLE
docs: downgrade cobrapy to 0.13.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sympy==1.1.1
 equilibrator_api==0.1.11
 libChEBIpy==1.0.7
 pytest==3.2.5
-cobra==0.14.2
+cobra==0.13.4
 seaborn==0.9.0
 beautifulsoup4==4.7.1
 scikit_learn==0.20.3


### PR DESCRIPTION
### Main improvements in this PR:
Downgrading cobrapy version until this issue is solved: https://github.com/opencobra/cobrapy/issues/819

cobrapy version 0.14.2 cause reconstruct_scoGEM.py to fail.

**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/sco-GEM#required-software) for running the model
- [x] Selected `devel` as a target branch (top left drop-down menu)
- [x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/sco-GEM) about this PR
