### PR TITLE
refactor: separate requirements.txt for sulheim2020

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -1,4 +1,2 @@
-# ComplementaryScripts
-The ComplementaryScripts folder is where scripts are stored for curation, etc. Scripts should be stored as flat-text format in their appropriate subfolder.
-
-*Please do not remove this file*
+# code
+This folder stores scripts for curation, etc. Scripts should be stored as flat-text format in their appropriate subfolder.

--- a/code/export.py
+++ b/code/export.py
@@ -219,7 +219,7 @@ def sort_reactions(Sco_GEM):
 def write_requirements_fun(directory, force = True):
     directory = str(directory)
     if force:
-        subprocess.run(["pipreqs", "--force", "."], cwd = directory)
+        subprocess.run(["pipreqs", "--ignore", "code/sulheim2020", "--force", "."], cwd = directory)
     else:
         subprocess.run(["pipreqs", "."], cwd = directory)
 

--- a/code/sulheim2020/README.md
+++ b/code/sulheim2020/README.md
@@ -1,0 +1,2 @@
+# sulheim2020
+This folder contains scripts related to the [Sulheim _et al._ (2020)](https://doi.org/10.1016/j.isci.2020.101525) publication. Its own requirements.txt is provided, replace the file in the repository root.

--- a/code/sulheim2020/requirements.txt
+++ b/code/sulheim2020/requirements.txt
@@ -1,0 +1,16 @@
+cobra==0.20.0
+requests==2.22.0
+numpy==1.19.5
+pandas==1.2.0
+beautifulsoup4==4.9.3
+bioservices==1.7.11
+equilibrator_api==0.4.0
+export==0.1.2
+libchebipy==1.0.10
+matplotlib==3.3.4
+memote==0.12.0
+pytest==6.2.2
+pythoncyc==2.0.2
+PyYAML==5.4.1
+scipy==1.6.0
+seaborn==0.11.1

--- a/data/README.md
+++ b/data/README.md
@@ -1,4 +1,2 @@
-# ComplementaryData
-The ComplementaryData folder is where data is stored that is used for curation, model testing, etc. Data should be stored as delimited text format (CSV) in their appropriate subfolder.
-
-*Please do not remove this file*
+# data
+In this folder data is stored that is used for curation, model testing, etc. Data should be stored as delimited text format (CSV or TSV) in their appropriate subfolder.

--- a/data/sulheim2020/README.md
+++ b/data/sulheim2020/README.md
@@ -1,0 +1,2 @@
+# sulheim2020
+This folder contains data related to the [Sulheim _et al._ (2020)](https://doi.org/10.1016/j.isci.2020.101525) publication.

--- a/model/README.md
+++ b/model/README.md
@@ -1,4 +1,2 @@
-# ModelFiles
-The ModelFiles folder is where the scoGEM model is stored in a variety of file formats in their respective sub-folder. The XML format is preferred for model exchange, simulation, curation etc., while the other formats primarily function to highlight changes in the model (YML and TXT).
-
-*Please do not remove this file*
+# model
+In this folder the sco-GEM model is stored in a variety of non-binary file formats. The XML format is preferred for model exchange, simulation, curation etc., while the other formats primarily function to highlight changes in the model (YML).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,3 @@
 pandas==1.2.0
-numpy==1.19.5
-requests==2.25.1
 cobra==0.20.0
-beautifulsoup4==4.9.3
-bioservices==1.7.11
-equilibrator_api==0.4.0
-libchebipy==1.0.10
-matplotlib==3.3.4
-memote==0.12.0
-pytest==6.2.2
-pythoncyc==2.0.2
-PyYAML==5.4.1
-scipy==1.6.0
-seaborn==0.11.1
+python-dotenv==0.15.0


### PR DESCRIPTION
### Main improvements in this PR:
Contributing towards #118. For main model development, it is not required to replicate Sulheim _et al._ (2020) as documented in `code/sulheim2020`. Therefore, ignore that folder for the main `requirements.txt` in the repository root, while having a separate `requirements.txt` in the sulheim2020 folder.

- feat:
  - separate `requirements.txt` for sulheim2020

**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/sco-GEM#required-software) for running the model
- [x] Selected `devel` as a target branch (top left drop-down menu)
