### PR TITLE
fix: block redox pseudorxns by default

### DIFF
--- a/code/curation/v1_3_0.py
+++ b/code/curation/v1_3_0.py
@@ -267,6 +267,14 @@ def add_model_id(model):
     # Closes issue #128
     model.id = "Sco_GEM"
 
+def block_pseudodonor_acceptor_rxn(model):
+    # Blocks the pseudoreactions that connect the donor and acceptor
+    # pseudometabolites to NAD(P)(H) by default.
+    pseudo_rxns = ['PSEUDO_ACCEPTOR_NADP','PSEUDO_ACCEPTOR_NAD','PSEUDO_DONOR_NADPH','PSEUDO_DONOR_NADH']
+    for i in pseudo_rxns:
+        r = model.reactions.get_by_id(i)
+        r.knock_out()
+
 if __name__ == '__main__':
     model = read_sbml_model("../../model/Sco-GEM.xml")
     model = export.get_latest_master_unversioned()
@@ -275,6 +283,7 @@ if __name__ == '__main__':
     correct_pubchem(model)
     add_gene_annotation(model)
     correct_metabolite_annotations(model)
+    block_pseudodonor_acceptor_rxn(model)
     export.export(model, formats = "xml", write_requirements = 0, objective = "BIOMASS_SCO_tRNA")
     model = read_sbml_model("../../model/Sco-GEM.xml") # Extra round of I/O to consistently output single GO and PFAM annotations in YAML file
     export.export(model, formats = ["xml", "yml"], write_requirements = 1, objective = "BIOMASS_SCO_tRNA")

--- a/model/Sco-GEM.yml
+++ b/model/Sco-GEM.yml
@@ -32505,8 +32505,8 @@
     - metabolites: !!omap
       - acceptor_c: 1.0
       - nad_c: -1.0
-    - lower_bound: -1000.0
-    - upper_bound: 1000.0
+    - lower_bound: 0.0
+    - upper_bound: 0.0
     - gene_reaction_rule: ''
     - annotation: !!omap
       - sbo: SBO:0000631
@@ -32517,8 +32517,8 @@
     - metabolites: !!omap
       - acceptor_c: 1.0
       - nadp_c: -1.0
-    - lower_bound: -1000.0
-    - upper_bound: 1000.0
+    - lower_bound: 0.0
+    - upper_bound: 0.0
     - gene_reaction_rule: ''
     - annotation: !!omap
       - sbo: SBO:0000631
@@ -32529,8 +32529,8 @@
     - metabolites: !!omap
       - donor_c: 1.0
       - nadh_c: -1.0
-    - lower_bound: -1000.0
-    - upper_bound: 1000.0
+    - lower_bound: 0.0
+    - upper_bound: 0.0
     - gene_reaction_rule: ''
     - annotation: !!omap
       - sbo: SBO:0000631
@@ -32541,8 +32541,8 @@
     - metabolites: !!omap
       - donor_c: 1.0
       - nadph_c: -1.0
-    - lower_bound: -1000.0
-    - upper_bound: 1000.0
+    - lower_bound: 0.0
+    - upper_bound: 0.0
     - gene_reaction_rule: ''
     - annotation: !!omap
       - sbo: SBO:0000631


### PR DESCRIPTION

### Main improvements in this PR:
- fix
  - by default block the `PSEUDO_ACCEPTOR_NADP`, `PSEUDO_ACCEPTOR_NAD`, `PSEUDO_DONOR_NADPH` and `PSEUDO_DONOR_NADH` reactions, that are included to be able to activate reactions with unknown redox co-factor (donor or acceptor), but also has the risk to introduce unrealistic loops and unnaturally links NADPH and NADH pools. Reactions will remain in the model to allow enabling the reactions with unknown redox co-factor.
 
**I hereby confirm that I have:**

- [x] Tested my code with [all requirements](https://github.com/SysBioChalmers/sco-GEM#required-software) for running the model
- [x] Selected `devel` as a target branch (top left drop-down menu)